### PR TITLE
check if first argument is an array or null

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,10 +6,15 @@ var diff = function(a, b) {
   });
 };
 
+var isObject = function(obj) {
+    return (typeof obj === 'object' && !Array.isArray(obj));
+};
+
 module.exports = function(obj, keys) {
-  if (obj !== null && typeof obj !== 'object') {
+  if (obj === null || !isObject(obj)) {
     throw new Error('First argument must be an object.');
   }
+
   if (!Array.isArray(keys)) {
     throw new Error('Second argument must be an array.');
   }

--- a/test.js
+++ b/test.js
@@ -25,17 +25,37 @@ describe("has key check", function() {
     assert(!hasProperties(negitive, mandatory));
   });
 
-  xit("should throw exception", function() {
+  it("should throw exception", function() {
     try {
       hasProperties('', []);
+      assert.fail();
     } catch (err) {
       assert.equal(err, 'Error: First argument must be an object.');
     }
   });
 
-  xit("should throw exception", function() {
+  it("should throw exception", function() {
     try {
-      hasProperties(' ', []);
+      hasProperties([], []);
+      assert.fail();
+    } catch (err) {
+      assert.equal(err, 'Error: First argument must be an object.');
+    }
+  });
+
+  it("should throw exception", function() {
+    try {
+      hasProperties(null, []);
+      assert.fail();
+    } catch (err) {
+      assert.equal(err, 'Error: First argument must be an object.');
+    }
+  });
+
+  it("should throw exception", function() {
+    try {
+      hasProperties(undefined, []);
+      assert.fail();
     } catch (err) {
       assert.equal(err, 'Error: First argument must be an object.');
     }


### PR DESCRIPTION
Currently this fails

``` js
hasProps(null, ['foo']);
// TypeError: Object.keys called on non-object
```

and if you pass an array you get `false`

``` js
hasProps([], ['foo']);
// => false
```

My PR changes the behaviour, so it fails "correctly" if you pass a none object as the first argument.
